### PR TITLE
Read default ENV variables for unknown CI

### DIFF
--- a/src/main/kotlin/ServiceInfoParser.kt
+++ b/src/main/kotlin/ServiceInfoParser.kt
@@ -94,7 +94,13 @@ class ServiceInfoParser(val envGetter: EnvGetter) {
                 branch = envGetter("BITRISE_GIT_BRANCH"),
                 buildUrl = envGetter("BITRISE_BUILD_URL")
             )
-            else -> ServiceInfo("other")
+            else -> ServiceInfo(
+                    name = envGetter("CI_NAME") ?: "other",
+                    number = envGetter("CI_BUILD_NUMBER"),
+                    pr = envGetter("CI_PULL_REQUEST"),
+                    branch = envGetter("CI_BRANCH"),
+                    buildUrl = envGetter("CI_BUILD_URL")
+            )
         }
     }
 }

--- a/src/test/kotlin/ServiceInfoParserTest.kt
+++ b/src/test/kotlin/ServiceInfoParserTest.kt
@@ -227,11 +227,51 @@ internal class ServiceInfoParserTest {
     }
 
     @Test
-    fun `ServiceInfoParser parses unidentifiable ci as other`() {
+    fun `ServiceInfoParser parses unidentifiable ci as other when no env is set`() {
         val envGetter = createEnvGetter(emptyMap())
 
         val actual = ServiceInfoParser(envGetter).parse()
         val expected = ServiceInfo("other")
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `ServiceInfoParser parses unidentifiable ci with default env on master`() {
+        val envGetter = createEnvGetter(mapOf(
+            "CI_NAME" to "teamcity",
+            "CI_BUILD_NUMBER" to "123123",
+            "CI_BUILD_URL" to "https://localhost:8111/viewLog.html?buildId=123123",
+            "CI_BRANCH" to "master",
+        ))
+
+        val actual = ServiceInfoParser(envGetter).parse()
+        val expected = ServiceInfo(
+            name = "teamcity",
+            number = "123123",
+            buildUrl = "https://localhost:8111/viewLog.html?buildId=123123",
+            branch = "master",
+        )
+        assertEquals(expected, actual)
+    }
+
+    @Test
+    fun `ServiceInfoParser parses unidentifiable ci with default env on pr`() {
+        val envGetter = createEnvGetter(mapOf(
+            "CI_NAME" to "teamcity",
+            "CI_BUILD_NUMBER" to "123123",
+            "CI_BUILD_URL" to "https://localhost:8111/viewLog.html?buildId=123123",
+            "CI_BRANCH" to "foobar",
+            "CI_PULL_REQUEST" to "11",
+        ))
+
+        val actual = ServiceInfoParser(envGetter).parse()
+        val expected = ServiceInfo(
+            name = "teamcity",
+            number = "123123",
+            buildUrl = "https://localhost:8111/viewLog.html?buildId=123123",
+            branch = "foobar",
+            pr = "11"
+        )
         assertEquals(expected, actual)
     }
 


### PR DESCRIPTION
Use the values of the recommended ENV variables for non-supported CI's.
See https://docs.coveralls.io/supported-ci-services#insert-your-ci-here

Merging it locally now, the [original one](https://github.com/nbaztec/coveralls-jacoco-gradle-plugin/pull/48) is not reviewed yet.